### PR TITLE
Ensure sentiment uses DatetimeIndex before joining

### DIFF
--- a/oroprimero.py
+++ b/oroprimero.py
@@ -233,12 +233,8 @@ def prepare_dataset(prices: pd.DataFrame, sentiment: pd.Series, lags: int = 5) -
 
     if not sentiment.empty:
         sentiment_idx = pd.to_datetime(sentiment.index)
-        df = df.merge(
-            sentiment.rename("sentiment"),
-            left_index=True,
-            right_index=True,
-            how="left",
-        )
+        sentiment = pd.Series(sentiment.values, index=sentiment_idx, name="sentiment")
+        df = df.join(sentiment, how="left")
         df["sentiment"].fillna(method="ffill", inplace=True)
         df["sentiment"].fillna(0.0, inplace=True)
     else:


### PR DESCRIPTION
## Summary
- recreate the sentiment series with a DatetimeIndex before combining with price data
- join the sentiment scores onto the price frame while preserving forward- and zero-filling

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0844c5048833283f09e7ddca34253